### PR TITLE
fix(brave): detect if Nimiq class is available instead of just relyin…

### DIFF
--- a/src/components/nimiq-widget/nimiq-widget.tsx
+++ b/src/components/nimiq-widget/nimiq-widget.tsx
@@ -94,7 +94,13 @@ export class Widget {
       let script = document.createElement('script');
       script.type = 'text/javascript';
       script.src = 'https://cdn.nimiq.com/nimiq.js';
-      script.addEventListener('load', () => resolve(script), false);
+      script.addEventListener('load', () => {
+        if ((window as any).Nimiq) {
+          resolve(script)
+        } else {
+          reject(script)
+        }
+      }, false);
       script.addEventListener('error', () => reject(script), false);
       document.body.appendChild(script);
   });


### PR DESCRIPTION
Add detection for `window.Nimiq` after dynamically injecting script to make sure we can use Nimiq.

Resolves #2 